### PR TITLE
Add sign-up sign-in and session cookies in remix

### DIFF
--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -1,0 +1,50 @@
+import { json, redirect } from "@remix-run/node"; // or cloudflare/deno
+import { useLoaderData } from "@remix-run/react";
+import { getSession } from "../session";
+
+export const loader = async ({ request }) => {
+  // The browser should automatically send the `sessionid` header cookie when this route is loaded.
+  const sessionIdSession = await getSession(request.headers.get("Cookie"));
+  console.log("sessionIdSession in profile", sessionIdSession.data);
+
+  // Ensure that the `sessionid` is present.
+  if (!sessionIdSession.has("_wherecanwedance_session")) {
+    // If it is not present, then the user has not been logged in.
+    console.log("session id not present");
+    throw redirect("/");
+  }
+
+  // change to a current user route
+  const response = await fetch("http://127.0.0.1:3000/api/v1/users/current", {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Cookie: Object.entries(sessionIdSession.data)
+        .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+        .join("; "),
+    },
+  });
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error(`HTTP error! status: ${response.status}: Unauthorized`);
+    }
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const data = await response.json();
+  console.log("data", data);
+  return json(data);
+};
+
+export default function Index() {
+  const user = useLoaderData<typeof loader>();
+
+  return (
+    <div>
+      <h1>Profile page</h1>
+      <p>email: {user?.email}</p>
+      <p>username: {user?.username}</p>
+    </div>
+  );
+}

--- a/app/routes/resources.signin.tsx
+++ b/app/routes/resources.signin.tsx
@@ -1,4 +1,6 @@
 import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+import setCookie from "set-cookie-parser";
+import { getSession, commitSession } from "../session";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   // get the form data from the POST
@@ -16,12 +18,39 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       "Content-Type": "application/json",
       Accept: "*/*",
     },
+    credentials: "include",
     body: JSON.stringify(data),
   });
 
-  console.log("response", response);
+  const setCookieHeader = response.headers.get("Set-Cookie");
+  if (!setCookieHeader) return;
+  const parsedResponseCookies = setCookie.parse(
+    setCookie.splitCookiesString(setCookieHeader)
+  );
+
+  const sessionIdCookie = parsedResponseCookies.find(
+    (cookie) => cookie.name === "_wherecanwedance_session"
+  );
+
+  if (!sessionIdCookie) {
+    // No `sessionid` cookie in the fetch response means something went wrong.
+    // Should return error
+    return;
+  }
+
+  const headers = new Headers();
+  // Store the response's `sessionid` cookie into the headers.
+  const { name, value, ...sessionIdCookieSerializeOptions } = sessionIdCookie;
+  const sessionIdSession = await getSession(request.headers.get("Cookie"));
+  sessionIdSession.set(name, value);
+
+  headers.append(
+    "Set-Cookie",
+    await commitSession(sessionIdSession, sessionIdCookieSerializeOptions)
+  );
+
   if (response.ok) {
-    return redirect("/");
+    return redirect("/profile", { headers });
   } else {
     let errorData = await response.json();
     console.error("Error response from server:", errorData); // Log the error details

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -14,8 +14,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     },
   };
 
-  console.log("data", data);
-
   const response = await fetch("http://127.0.0.1:3000/api/v1/users/signup", {
     method: "POST",
     headers: {
@@ -59,10 +57,7 @@ export default function Index() {
             <input name="password" type="password" required />
           </div>
           <div className="p-2">
-            <label htmlFor="password-confirmation">
-              {" "}
-              password-confirmation{" "}
-            </label>
+            <label htmlFor="password-confirmation">confirm password</label>
             <input name="password-confirmation" type="password" required />
           </div>
           <button type="submit">Create</button>

--- a/app/session.ts
+++ b/app/session.ts
@@ -1,0 +1,18 @@
+import { createCookieSessionStorage } from "@remix-run/node";
+
+const SESSION_SECRET =
+  "eede8fa4ff45b950b1cfec4fdb657a4a8cd21032552f48c2a7d0e8ea0c773de4fecb9867398311e5df53151b5c39081371b8ccb7ed1efe2a477ec4a6769de739";
+
+const { getSession, commitSession, destroySession } =
+  createCookieSessionStorage({
+    cookie: {
+      name: "_wherecanwedance_session",
+      path: "/",
+      secrets: [SESSION_SECRET],
+      secure: process.env.NODE_ENV === "production",
+      httpOnly: true,
+      // More cookie options could be added here, but we will be using the cookie options from the fetch responses later.
+    },
+  });
+
+export { getSession, commitSession, destroySession };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
         "@remix-run/serve": "^2.9.2",
         "isbot": "^4.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "set-cookie-parser": "^2.6.0"
       },
       "devDependencies": {
         "@remix-run/dev": "^2.9.2",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
+        "@types/set-cookie-parser": "^2.4.9",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
         "autoprefixer": "^10.4.19",
@@ -2079,6 +2081,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.9.tgz",
+      "integrity": "sha512-bCorlULvl0xTdjj4BPUHX4cqs9I+go2TfW/7Do1nnFYWS0CPP429Qr1AY42kiFhCwLpvAkWFr1XIBHd8j6/MCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "2.0.10",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "@remix-run/serve": "^2.9.2",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "set-cookie-parser": "^2.6.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.9.2",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
+    "@types/set-cookie-parser": "^2.4.9",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "autoprefixer": "^10.4.19",


### PR DESCRIPTION
# Overview
Add sign-up sign-in and session cookies in remix

# Testing
- Use `introducting-api-endpoints-2` branch on the backend, this is the PR: https://github.com/Dancewise/wherecanwedance/pull/122
- Test signing up and logging in
- When you log in you should be redirected to the user profile page